### PR TITLE
SVG Controls (Panning, Zoom)

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "web-provenance",
+	"name": "frontend",
 	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -1228,14 +1228,6 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
 			"integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
-			"requires": {
-				"@types/lodash": "*"
-			}
-		},
-		"@types/lodash.uniqueid": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.6.tgz",
-			"integrity": "sha512-WXXsDm7Q1SiAeCG9ubCiDxOuLEDi5x+Crx8SgwTFgBtofATwK1jAeSbGz2bHlfqWezi7mcjynenlBFCeDLhHlw==",
 			"requires": {
 				"@types/lodash": "*"
 			}
@@ -6770,11 +6762,6 @@
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
 		},
-		"lodash.uniqueid": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
-			"integrity": "sha1-MmjyanyI5PSxdY1nknGBTjH6WyY="
-		},
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -9904,6 +9891,11 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
+		},
+		"svg-pan-zoom": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/svg-pan-zoom/-/svg-pan-zoom-3.6.0.tgz",
+			"integrity": "sha512-ZBEL2z/n/W2fLLFzn3NTQgd+7QEfbrKvKmu29U3qvMflmJgLaWkwKbOzWJYESFidTiGYMHkijAKmY6m64moyYg=="
 		},
 		"svg-tags": {
 			"version": "1.0.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,6 +17,7 @@
     "fuse.js": "^3.4.5",
     "lodash.debounce": "^4.0.8",
     "restyped-axios": "^2.0.0",
+    "svg-pan-zoom": "^3.6.0",
     "vue": "^2.6.10",
     "vue-function-api": "^2.0.6"
   },

--- a/packages/frontend/src/Visualizer.vue
+++ b/packages/frontend/src/Visualizer.vue
@@ -11,6 +11,7 @@
       zoom
       arrows
       drag
+      :pan.sync="pan"
       hulls
       :hull-dblclick="hullDblclick"
       :color-changes="colorChanges"
@@ -280,6 +281,9 @@ export default createComponent({
     // Whether to show the help information
     const showHelp = value(false);
 
+    // The pan of the visualization
+    const pan = value({ x: 0, y: 0 });
+
     // The selected study. This is set automatically when a new study is created or it can be opened from the search.
     const selectedStudy = value<SimulationStudy | null>(null);
 
@@ -535,10 +539,12 @@ export default createComponent({
 
     function nodeRightClick(e: MouseEvent, node: SingleNode) {
       e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
       const setCenter = () => {
         lineStart.value = {
-          x: node.x + node.width / 2,
-          y: node.y + node.height / 2,
+          x: pan.value.x + node.x + node.width / 2,
+          y: pan.value.y + node.y + node.height / 2,
         };
       };
 
@@ -549,8 +555,8 @@ export default createComponent({
         return nodes.value
           .filter(isSingleNode) // we can't make connections to group nodes
           .filter((n) => {
-            const ul = n; // upper left corner
-            const lr = { x: n.x + n.width, y: n.y + n.height }; // lower right corner
+            const ul = { x: n.x + pan.value.x, y: n.y + pan.value.y }; // upper left corner
+            const lr = { x: ul.x + n.width, y: ul.y + n.height }; // lower right corner
             return n !== node && point.x > ul.x && point.y > ul.y && lr.x > point.x && lr.y > point.y;
           });
       };
@@ -674,7 +680,11 @@ export default createComponent({
         onDidRightClick: (e: MouseEvent) => {
           nodeRightClick(e, node);
         },
-        onDidClick: () => {
+        onDidMousedown: (e: MouseEvent) => {
+          // Stop the pan/zoom tool from panning when the user clicks on a node
+          e.stopPropagation();
+        },
+        onDidClick: (e: MouseEvent) => {
           colorChanges.value.push({ node, color: SELECTED_NODE_OUTLINE });
 
           if (selectedNode.value) {
@@ -1084,6 +1094,7 @@ export default createComponent({
       nodes,
       lineStart,
       lineEnd,
+      pan,
       searchItems,
       expandStudy,
       legendProps,

--- a/packages/frontend/src/Visualizer.vue
+++ b/packages/frontend/src/Visualizer.vue
@@ -8,6 +8,7 @@
       :links="links"
       :nodes="nodes"
       force 
+      zoom
       arrows
       drag
       hulls

--- a/packages/frontend/src/components/D3.vue
+++ b/packages/frontend/src/components/D3.vue
@@ -3,6 +3,7 @@
     id="d3-svg"
     ref="svg" 
     class="svg"
+    @mousedown="startDrag"
     :height="height"
     :width="width"
   ><slot></slot></svg>
@@ -13,7 +14,7 @@ import * as d3 from 'd3';
 import { ID3, D3Link, D3Node, D3Hull, D3NodeCallbackKeys, D3NodeColorCombo } from '@/d3';
 import forceLink from '@/link';
 import forceManyBody from '@/manyBody';
-import { makeLookup, Lookup, intersection, createComponent, getRandomColor } from '@/utils';
+import { makeLookup, Lookup, intersection, createComponent, getRandomColor, addEventListener, update } from '@/utils';
 import { computed, watch, onMounted, value } from 'vue-function-api';
 import svgPanZoom from 'svg-pan-zoom';
 
@@ -37,6 +38,7 @@ export default createComponent({
     drag: { type: Boolean, default: false },
     zoom: { type: Boolean, default: false },
     hulls: { type: Boolean, default: false },
+    pan: { type: Object as () => { x: number, y: number } | undefined },
     height: { type: Number, default: 100 },
     width: { type: Number, default: 100 },
     arrowSize: { type: Number, default: 6 },
@@ -489,8 +491,10 @@ export default createComponent({
           svgPanZoomInstance = svgPanZoom(refs.svg, {
             fit: false,
             center: false,
-            controlIconsEnabled: true,
             dblClickZoomEnabled: false,
+            onPan: (newPan) => {
+              update(props, context, 'pan', newPan);
+            },
           });
 
           svgPanZoomInstance.pan(pan);
@@ -527,6 +531,14 @@ export default createComponent({
     return {
       addNode,
       addLink,
+      startDrag: () => {
+        const current = document.body.style.cursor;
+        document.body.style.cursor = 'grab';
+        const disposer = addEventListener('mouseup', () => {
+          document.body.style.cursor = current;
+          disposer.dispose();
+        });
+      },
     };
   },
 });

--- a/packages/frontend/src/utils.ts
+++ b/packages/frontend/src/utils.ts
@@ -533,3 +533,10 @@ export const merge = <T>(objects: Array<Lookup<T>>) => {
   });
   return lookup;
 };
+
+
+export const update = <Props, K extends keyof Props, V extends Props[K]>(
+  props: Props, context: { emit: (event: string, value: V) => void }, key: K, value: V,
+) => {
+  context.emit(`update:${key}`, value);
+};


### PR DESCRIPTION
`svg-pan-zoom` was added to provide panning and zoom controls to the visualization.

This removes the need to constrain nodes to the screen because we can now pan (See #25).