### PR TITLE
Circular Dependencies

### DIFF
--- a/packages/frontend/src/utils.ts
+++ b/packages/frontend/src/utils.ts
@@ -40,7 +40,7 @@ export function getLabel(
   node: ProvenanceNode,
   definition: NodeDefinition | undefined,
   lookup: StudyLookup,
-  modelVersionLookup: Lookup<number | undefined>,
+  modelVersionLookup: Lookup<number | undefined | string>,
 ): string {
   if (node.label) {
     return node.label;


### PR DESCRIPTION
Previously, WebProv frontend would break if you created a circular dependency. Now, it only breaks part of the rendering process and shows an error to the user.

