### PR TITLE
version numbers are now only unique within a study

### DIFF
--- a/packages/backend/src/cypher.ts
+++ b/packages/backend/src/cypher.ts
@@ -344,7 +344,11 @@ export const initialize = async () => {
     for (const fieldName of keys(fields)) {
       const fieldInformation = fields[fieldName];
       if (fieldInformation.unique || fieldInformation.primary) {
-        await session.run(`CREATE CONSTRAINT ON (n:${schema.name}) ASSERT n.${fieldName} IS UNIQUE`);
+        try {
+          await session.run(`CREATE CONSTRAINT ON (n:${schema.name}) ASSERT n.${fieldName} IS UNIQUE`);
+        } catch {
+          // Ignore if already exists
+        }
       }
     };
   };

--- a/packages/frontend/src/components/NodeFormCard.vue
+++ b/packages/frontend/src/components/NodeFormCard.vue
@@ -32,7 +32,7 @@
     </b-field>
 
 
-    <b-field label="InformationField" style="flex-direction: column; align-items: flex-start;">
+    <b-field label="Information Fields" style="flex-direction: column; align-items: flex-start;">
       <div v-for="(field, j) in fields" :key="j" style="display: flex">
         <b-field>
           <b-input placeholder="Key" :value="field.key" @input="updateKey(j, $event)"></b-input>

--- a/packages/frontend/src/hooks.ts
+++ b/packages/frontend/src/hooks.ts
@@ -113,7 +113,7 @@ export const useRules = () => {
 export const useDefinitions = () => {
   const definitions = ref<NodeDefinition[]>([]);
   const definitionLookup = computed(() => makeLookup(definitions.value));
-  const getDefinition = (node: ProvenanceNode) => {
+  const getDefinition = (node: ProvenanceNode): NodeDefinition | undefined => {
     if (!definitionLookup.value.hasOwnProperty(node.definitionId)) {
       return undefined;
     }
@@ -223,20 +223,20 @@ export const useDefinitions = () => {
     const lookup: Lookup<number> = {}; // the version lookup (node id -> version)
     sorted.forEach((node) => {
       const definition = getDefinition(node.node);
-      if (!definition) {
-        lookup[node.id] = 0;
-        return;
-      }
 
-      if (!indices.hasOwnProperty(definition.id)) {
-        indices[definition.id] = 0;
+      // The ID is a concatenation of the definition and study
+      // This makes it so version numbers are only unique within a study
+      const id = "" + (definition ? definition.id : "") + node.node.studyId;
+
+      if (!indices.hasOwnProperty(id)) {
+        indices[id] = 0;
       }
 
       // add one before so that the number starts at 1
-      indices[definition.id]++;
+      indices[id]++;
 
       // start the number at 1, not 0
-      lookup[node.id] = indices[definition.id];
+      lookup[node.id] = indices[id];
     });
 
     return {


### PR DESCRIPTION
As described in the documentation (see below), the version numbers should be unique within a study. Previously, they were unique within all nodes but this PR fixes this issue.
> The `version` is an integer (starting at `1`) that is unique to the node type within the study.

![image](https://user-images.githubusercontent.com/18077531/91045805-d0b8c000-e5ed-11ea-9c12-6f481496b925.png)
> This is how the version numbers showed up previously. Note that "A1" and "A2" are in different studies. Since they are in different studies, they should both be "A1".